### PR TITLE
Sbt 1.0.0 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,6 @@ name := "sbt-webpack-execute"
 
 organization := "de.sebbraun.sbt"
 
-scalaVersion := "2.10.6"
-
 licenses := Seq(
   "MIT" -> url("http://opensource.org/licenses/MIT")
 )
@@ -37,6 +35,7 @@ publishTo := {
 publishMavenStyle := true
 
 sbtPlugin := true
+crossSbtVersions := Seq("0.13.6", "1.0.0")
 
 ScriptedPlugin.scriptedSettings
 

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ publishTo := {
 publishMavenStyle := true
 
 sbtPlugin := true
-crossSbtVersions := Seq("0.13.6", "1.0.0")
+crossSbtVersions := Seq("0.13.16", "1.0.0")
 
 ScriptedPlugin.scriptedSettings
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.13
+sbt.version = 0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := Level.Warn
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
Solution for #6 (which can be closed **after release**).

The release hack was partially borrowed from wartremover build. For whatever reason `releaseStepCommandAndRemaining("^ scripted")` continues after error, which negates the whole point of tests. So I did roughly the same thing manually with `releaseStepCommand("^^ x.x.x")`.